### PR TITLE
Removed dependency duration_as_u128 so we are one step closer to stable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(duration_as_u128)]
 #![feature(test)]
 
 extern crate test;
@@ -24,7 +23,7 @@ pub enum SortMethod {
 /// Return the current time in seconds as a float
 pub fn current_time_secs() -> f64 {
     match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(n) => n.as_millis() as f64 / 1000.0,
+        Ok(n) => (n.as_secs() as u128 * 1000 + n.subsec_millis() as u128) as f64 / 1000.0,
         Err(e) => {
             error!("invalid system time: {}", e);
             process::exit(1);


### PR DESCRIPTION
It would be great if fe could run on stable so removing feature flags will help move in that direction.  This should be equivalent to the original but without the feature flag.

Signed-off-by: zethra <jediben97@gmail.com>