### PR TITLE
Remove test crate and test flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
 #![feature(duration_as_u128)]
-#![feature(test)]
-
-extern crate test;
 
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
The unstable features of test aren't being used.
This is blocking moving to stable.

Signed-off-by: zethra <jediben97@gmail.com>